### PR TITLE
CHORE: Relax `engines.node` and `engines.npm` for updated versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
     "node": "^14 || ^15 || ^16",
-    "npm": ">=6.14.8 <=8.19.2"
+    "npm": "^6.14.8 || ^7 || ^8"
   },
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/mysense-ai/ServerlessPlugin-SSMPublish#readme",
   "engines": {
-    "node": ">=14.0.0 <=16.18.1",
+    "node": "^14 || ^15 || ^16",
     "npm": ">=6.14.8 <=8.19.2"
   },
   "private": false,


### PR DESCRIPTION
'cause all our builds are broken with the latest GitHub runners.